### PR TITLE
Add Support for File Content HTTP Responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ The params have to look like this (there are not default values for the params!)
 }
 ```
 
+### sendFileResponse(responseObject, callbackSuccess, callbackError) (currently Android-only support)
+
+This method allows sending file content in response to an http request.  It is intended that this would be used in conjunction with cordova-plugin-file to locate the path of the file data to be sent.
+
+The response object should look like this.  Here, the provided path should be accessible by your cordova app and the type should be the mime type of the file.  Note that the MIME type of the file can be found from the [.type property of the File object](https://developer.mozilla.org/en-US/docs/Web/API/File).
+```
+{
+	path: '/sdcard0/Downloads/whatever.txt',
+	type: 'text/plain'
+}
+```
+
 ## Example
 
 ```javascript
@@ -106,4 +118,3 @@ Special thanks to:
 
 - https://github.com/NanoHttpd/nanohttpd
 - https://github.com/swisspol/GCDWebServer
-

--- a/src/android/Webserver.java
+++ b/src/android/Webserver.java
@@ -101,7 +101,8 @@ public class Webserver extends CordovaPlugin {
     }
 
     private void sendFileResponse(JSONArray args, CallbackContext callbackContext) throws JSONException {
-      this.responses.put('file', args.get(1));
+      Log.d(this.getClass().getName(), "Got sendResponse: " + args.toString());
+      this.responses.put("file", args.get(0));
       callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK));
     }
 

--- a/src/android/Webserver.java
+++ b/src/android/Webserver.java
@@ -44,6 +44,10 @@ public class Webserver extends CordovaPlugin {
             this.sendResponse(args, callbackContext);
             return true;
         }
+        else if ("sendFileResponse".equals(action)) {
+            this.sendFileResponse(args, callbackContext);
+            return true;
+        }
         return false;  // Returning false results in a "MethodNotFound" error.
     }
 
@@ -94,6 +98,11 @@ public class Webserver extends CordovaPlugin {
         Log.d(this.getClass().getName(), "Got sendResponse: " + args.toString());
         this.responses.put(args.getString(0), args.get(1));
         callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK));
+    }
+
+    private void sendFileResponse(JSONArray args, CallbackContext callbackContext) throws JSONException {
+      this.responses.put('file', args.get(1));
+      callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK));
     }
 
     /**

--- a/src/www/webserver.js
+++ b/src/www/webserver.js
@@ -4,6 +4,7 @@ const WEBSERVER_CLASS = 'Webserver';
 const START_FUNCTION = 'start';
 const ONREQUEST_FUNCTION = 'onRequest';
 const SENDRESPONSE_FUNCION = 'sendResponse';
+const SENDFILE_FUNCION = 'sendFileResponse';
 const STOP_FUNCTION = 'stop';
 
 export function start(success_callback, error_callback, port) {
@@ -41,6 +42,21 @@ export function sendResponse(
     error_callback,
     WEBSERVER_CLASS,
     SENDRESPONSE_FUNCION,
+    [requestId, params]
+  );
+}
+
+export function sendFile(
+  requestId,
+  params,
+  success_callback,
+  error_callback
+) {
+  exec(
+    success_callback,
+    error_callback,
+    WEBSERVER_CLASS,
+    SENDFILE_FUNCION,
     [requestId, params]
   );
 }

--- a/webserver.js
+++ b/webserver.js
@@ -6,6 +6,7 @@ Object.defineProperty(exports, "__esModule", {
 exports.start = start;
 exports.onRequest = onRequest;
 exports.sendResponse = sendResponse;
+exports.sendFile = sendFile;
 exports.stop = stop;
 
 var _exec = require('cordova/exec');
@@ -18,6 +19,7 @@ var WEBSERVER_CLASS = 'Webserver';
 var START_FUNCTION = 'start';
 var ONREQUEST_FUNCTION = 'onRequest';
 var SENDRESPONSE_FUNCION = 'sendResponse';
+var SENDFILE_FUNCION = 'sendFileResponse';
 var STOP_FUNCTION = 'stop';
 
 function start(success_callback, error_callback, port) {
@@ -36,6 +38,10 @@ function onRequest(success_callback) {
 
 function sendResponse(requestId, params, success_callback, error_callback) {
   (0, _exec2.default)(success_callback, error_callback, WEBSERVER_CLASS, SENDRESPONSE_FUNCION, [requestId, params]);
+}
+
+function sendFile(requestId, params, success_callback, error_callback) {
+  (0, _exec2.default)(success_callback, error_callback, WEBSERVER_CLASS, SENDFILE_FUNCION, [requestId, params]);
 }
 
 function stop(success_callback, error_callback) {


### PR DESCRIPTION
This PR uses some of the demo NanoHTTPD code to enable support for sending the contents of a file in the response to an HTTP request.  It currently only provides this support for Android because I don't any Apple to develop or test an implementation for iOS.