### PR TITLE
iOS: clean up by removing the handled response

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -28,6 +28,7 @@
 
   <platform name="ios">
     <source-file src="src/ios/Webserver.swift" />
+    <source-file src="src/ios/SynchronizedDictionary.swift" />
     <dependency id="cordova-plugin-add-swift-support" version="1.6.1"/>
 
     <framework src="libz.tbd" />

--- a/src/ios/SynchronizedDictionary.swift
+++ b/src/ios/SynchronizedDictionary.swift
@@ -1,0 +1,25 @@
+public class SynchronizedDictionary<KeyType:Hashable, ValueType> {
+    private var dictionary: [KeyType:ValueType] = [:]
+    private let accessQueue = DispatchQueue(label: "SynchronizedDictionaryAccess", attributes: .concurrent)
+
+    public func removeValue(forKey: KeyType) {
+        self.accessQueue.async(flags:.barrier) {
+            self.dictionary.removeValue(forKey: forKey)
+        }
+    }
+
+    public subscript(key: KeyType) -> ValueType? {
+        set {
+            self.accessQueue.async(flags:.barrier) {
+                self.dictionary[key] = newValue
+            }
+        }
+        get {
+            var element: ValueType?
+            self.accessQueue.sync {
+                element = self.dictionary[key]
+            }
+            return element
+        }
+    }
+}

--- a/src/ios/Webserver.swift
+++ b/src/ios/Webserver.swift
@@ -3,13 +3,13 @@
     let TIMEOUT: Int = 60 * 3 * 1000000
 
     var webServer: GCDWebServer = GCDWebServer()
-    var responses: Dictionary<String, Any> = [:]
+    var responses = SynchronizedDictionary<AnyHashable,Any?>()
     var onRequestCommand: CDVInvokedUrlCommand? = nil
 
     override func pluginInitialize() {
         self.webServer = GCDWebServer()
         self.onRequestCommand = nil
-        self.responses = [:]
+        self.responses = SynchronizedDictionary<AnyHashable,Any?>()
         self.initHTTPRequestHandlers()
     }
 
@@ -62,6 +62,9 @@
         for (key, value) in (responseDict["headers"] as! Dictionary<String, String>) {
             response?.setValue(value, forAdditionalHeader: key)
         }
+
+        // Remove the handled response
+        self.responses.removeValue(forKey: requestUUID)
 
         // Complete the async response
         completionBlock(response!)


### PR DESCRIPTION
Reduce the memory usage by removing the handled responses from the dictionary. Since the every request is handled by a separate thread it requires a thread-safe dictionary implementation. This modification contains a very basic thread-safe dictionary implementation.