### PR TITLE
Fix error on import GCDWebServer*.h file with cocoa pod framework

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -39,10 +39,18 @@
 
     <framework src="libz.tbd" />
     <framework src="libxml2.tbd" />
-    <framework src="GCDWebServer" type="podspec" spec="~> 3.5.2" />
 
+    <podspec>
+      <config>
+        <source url="https://github.com/CocoaPods/Specs.git"/>
+      </config>
+      <pods use-frameworks="true">
+        <pod name="GCDWebServer" spec="~> 3.5.2"/>
+      </pods>
+    </podspec>
+    
     <!-- GCDWebserver -->
-    <header-file src="src/ios/GCDWebServer-Bridging-Header.h"/>
+    <header-file src="src/ios/GCDWebServer-Bridging-Header.h" type="BridgingHeader"/>
 
   </platform>
 </plugin>

--- a/src/ios/GCDWebServer-Bridging-Header.h
+++ b/src/ios/GCDWebServer-Bridging-Header.h
@@ -1,6 +1,6 @@
-#import "GCDWebServer.h"
-#import "GCDWebServerDataRequest.h"
-#import "GCDWebServerDataResponse.h"
-#import "GCDWebServerFileResponse.h"
-#import "GCDWebServerResponse.h"
-#import "GCDWebServerRequest.h"
+#import <GCDWebServer/GCDWebServer.h>
+#import <GCDWebServer/GCDWebServerDataRequest.h>
+#import <GCDWebServer/GCDWebServerDataResponse.h>
+#import <GCDWebServer/GCDWebServerFileResponse.h>
+#import <GCDWebServer/GCDWebServerResponse.h>
+#import <GCDWebServer/GCDWebServerRequest.h>


### PR DESCRIPTION
GCDWebServer*.h was not found by xcode with the last version of plugin. This pull request fix the problem and update the plugin.xml by removing deprecated framework tag with attribute podspec.